### PR TITLE
Add Eyring-like limiting shear for hydrodynamic traction and emit per-angle friction data

### DIFF
--- a/test6666.txt
+++ b/test6666.txt
@@ -88,6 +88,12 @@ class EHLSolver:
         # Adjust as needed for your boundary regime (typical range ~0.05–0.12)
         # ------------------------
         self.mu_b = 0.12
+        # ------------------------
+        # Limiting shear model (Eyring-like)
+        # tau_lim = tau0 + alpha_tau * p
+        # ------------------------
+        self.tau0 = 2.0e6
+        self.alpha_tau = 0.02
 
         # ------------------------
         # Internal state variables updated per step
@@ -664,23 +670,24 @@ class EHLSolver:
         p_asp = np.maximum(Pa_nd, 0.0) * self.P0_ref     # Pa
         h = np.maximum(H_nd * R_eff, 1e-9)               # m
 
-        # Pressure gradient dp/dx (Pa/m)
-        dpdx = np.gradient(p_rey, dx_m)
-
         # Local viscosity (Pa*s), using current thermal field
         mu = self.c_mu(P_rey_nd, self.T_current)
 
         # Flow factors (optional inclusion consistent with your Reynolds formulation)
-        phi_x, phi_s = self.calc_flow_factors(H_nd)
+        _, phi_s = self.calc_flow_factors(H_nd)
 
         # Shear components (Pa)
         tau_couette = mu * phi_s * (self.Vs / h)
-        tau_poiseuille = -0.5 * h * phi_x * dpdx
-        tau_h = tau_couette + tau_poiseuille
+        tau_raw = tau_couette
+
+        # Limiting shear stress (Eyring-like)
+        tau_lim = self.tau0 + self.alpha_tau * p_rey
+        tau_lim = np.maximum(tau_lim, 1.0)
+        tau_h = tau_lim * np.tanh(tau_raw / tau_lim)
 
         # Integrate friction forces (N)
-        Fh = self.B * np.trapz(np.abs(tau_h), x_m)
-        Fa = self.B * np.trapz(self.mu_b * p_asp, x_m)
+        Fh = self.B * np.abs(np.trapezoid(tau_h, x_m))
+        Fa = self.B * np.trapezoid(self.mu_b * p_asp, x_m)
 
         Ft = Fh + Fa
 
@@ -904,6 +911,14 @@ def main():
     for rpm in RPM_LIST:
         res = solver.run_cam_cycle(rpm, verbose=True)
         all_results.append(res)
+
+        print(f"\n===== Hydrodynamic Friction vs Cam Angle (RPM {rpm}) =====")
+        for theta, fh in zip(res["theta_deg"], res["Fh"]):
+            print(f"{theta:.3f}\t{fh:.6e}")
+
+        print(f"\n===== Asperity Friction vs Cam Angle (RPM {rpm}) =====")
+        for theta, fa in zip(res["theta_deg"], res["Fa"]):
+            print(f"{theta:.3f}\t{fa:.6e}")
 
         # Per-RPM plots
         if PLOT_CAM_KINEMATICS:


### PR DESCRIPTION
### Motivation
- Reduce non-physical spikes/oscillations in hydrodynamic/asperity friction around the cam nose by addressing large local shear values and improve diagnostics. 
- Constrain hydrodynamic shear using a physics-based limiting-shear model rather than ad-hoc clipping to preserve model fidelity. 
- Make per-angle friction histories visible to help diagnose remaining irregularities in the profile. 
- Keep all kinematics, materials and roughness inputs unchanged as required.

### Description
- Introduce Eyring-like limiting shear parameters `self.tau0` and `self.alpha_tau` and compute a local limit `tau_lim = tau0 + alpha_tau * p` in `compute_friction_and_torque`.
- Replace the previous combined Couette+Poiseuille shear with a Couette-only raw shear `tau_couette`, then apply the limiting shear via `tau_h = tau_lim * tanh(tau_raw / tau_lim)` to ensure physically bounded traction.
- Switch numerical integration to `np.trapezoid` and take the appropriate absolute/net contribution when computing `Fh` and `Fa` to avoid sign-related artifacts in integrated friction.
- Add console output to print hydrodynamic (`Fh`) and asperity (`Fa`) friction versus cam angle for each RPM run to aid diagnostics and verification.

### Testing
- Ran the main script with `python test6666.txt` (after installing `numpy` and `matplotlib`) for `RPM_LIST = [300]`, which completed the full cam cycle successfully and printed per-angle friction tables; run time ~187.6s (within the 208s target). 
- Confirmed the solver completed the cycle and produced average torque output (`avg_torque`) and the friction vs angle lists without fatal errors. 
- Observed repeated Newton retries in some steps but the fallback logic allowed completion of the cycle; no automated test failures occurred. 
- Generated the cycle plots (controlled by toggles) and per-angle text output for validation and inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953646c39cc832f9f2ba845cf5fc35e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a physically bounded hydrodynamic shear model and exposes per-angle diagnostics.
> 
> - Adds limiting-shear params `tau0` and `alpha_tau`; computes `tau_lim = tau0 + alpha_tau * p` and applies `tau_h = tau_lim * tanh(tau_raw / tau_lim)` in `compute_friction_and_torque`
> - Uses Couette-only raw shear with shear flow factor; removes Poiseuille contribution from traction calc
> - Switches friction integrations to `np.trapezoid`; takes absolute/net contributions appropriately for `Fh` and `Fa`
> - Emits per-angle hydrodynamic (`Fh`) and asperity (`Fa`) friction tables in `main()`; existing plotting and solver flow retained
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcca278accc67ccace344cce2602e2a6e3e13323. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->